### PR TITLE
OT194-88 Create member model and migration

### DIFF
--- a/database/migrations/20220612173742-create-member.js
+++ b/database/migrations/20220612173742-create-member.js
@@ -1,0 +1,34 @@
+'use strict';
+module.exports = {
+  async up (queryInterface, Sequelize) {
+    await queryInterface.createTable('Members', {
+      id: {
+        type: Sequelize.STRING,
+        allowNull: false,
+        primaryKey: true,
+        defaultValue: Sequelize.UUIDV4
+      },
+      name: {
+        type: Sequelize.STRING,
+        allowNull: false
+      },
+      image: {
+        type: Sequelize.STRING
+      },
+      deletedAt: {
+        type: Sequelize.DATE
+      },
+      createdAt: {
+        allowNull: false,
+        type: Sequelize.DATE
+      },
+      updatedAt: {
+        allowNull: false,
+        type: Sequelize.DATE
+      }
+    });
+  },
+  async down (queryInterface, Sequelize) {
+    await queryInterface.dropTable('Members');
+  }
+};

--- a/database/models/member.js
+++ b/database/models/member.js
@@ -1,0 +1,31 @@
+'use strict';
+const {
+  Model
+} = require('sequelize');
+module.exports = (sequelize, DataTypes) => {
+  class Member extends Model {
+    /**
+     * Helper method for defining associations.
+     * This method is not a part of Sequelize lifecycle.
+     * The `models/index` file will call this method automatically.
+     */
+    static associate (models) {
+      // define association here
+    }
+  }
+  Member.init({
+    id: {
+      type: DataTypes.UUIDV4,
+      allowNull: false,
+      primaryKey: true,
+      defaultValue: DataTypes.UUIDV4
+    },
+    name: DataTypes.STRING,
+    image: DataTypes.STRING,
+    deletedAt: DataTypes.DATE
+  }, {
+    sequelize,
+    modelName: 'Member'
+  });
+  return Member;
+};


### PR DESCRIPTION
* Se crearon el modelo y la migración con el comando `npx sequelize-cli model:generate --name Member --attributes name:string,image:string,deletedAt:date`.
* Se modificaron ambos para utilizar `UUIDV4` en el campo id.

Ticket: https://alkemy-labs.atlassian.net/browse/OT194-88